### PR TITLE
ci: run tests on ubuntu-latest

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: StackStorm-Exchange/ci/.github/actions/checkout@master
         with:
-          st2-branch: master
+          st2-branch: v3.8
           lint-configs-branch: master
       - name: Install APT dependencies
         uses: StackStorm-Exchange/ci/.github/actions/apt-dependencies@master

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_and_test:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9"]

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -38,7 +38,7 @@ jobs:
 
     services:
       mongo:
-        image: mongo:3.4
+        image: mongo:7
         ports:
           - 27017:27017
       rabbitmq:


### PR DESCRIPTION
The Ubuntu 20.04 runner has been deprecated, but this is a requirement for StackStorm. Let's see if it runs on ubuntu-latest.