### PR TITLE
feat: use sample_name and ExternalRID for a sample

### DIFF
--- a/actions/workflows/generate_and_load_case.yaml
+++ b/actions/workflows/generate_and_load_case.yaml
@@ -105,7 +105,7 @@ tasks:
       - when: <% succeeded() and ctx().pipeline = "genomic-medicine-sweden/Twist_Solid" %>
         publish:
           - igene_panels: <% result().first().result.body.Panels %>
-          - case_name: <% ctx().sample_ids.first() %>
+          - case_name: "<% ctx().sample_ids.first() %>_<% result().first().result.body.ExternalRID %>"
           - sample_info: <% dict(zip(ctx().sample_ids, result().select($.result.body))) %>
         do: generate_load_config
 


### PR DESCRIPTION
feat: use sample_name and ExternalRID for a sample as a unique case_name in scout. For gms-solid